### PR TITLE
Automated releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        es_version: [ 8.6.1, 8.9.2 ]
+        es_version: [ 8.9.2, 8.15.2 ]
     steps:
       - name: Checkout project sources
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        es_version: [ 8.6.1, 8.9.2 ]
+    steps:
+      - name: Checkout project sources
+        uses: actions/checkout@v2
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set version
+        run: mvn --no-transfer-progress versions:set -DnewVersion=${{ matrix.es_version }}
+
+      - name: Build
+        run: mvn --no-transfer-progress package -Delasticsearch.version=${{ matrix.es_version }}
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: target/releases/*.zip

--- a/README.markdown
+++ b/README.markdown
@@ -250,6 +250,16 @@ mvn package
 
 After that build should be located in `./target/releases`.
 
+
+## Release
+
+To release for a new Elasticsearch version, add it to the versions in `.github/workflows/build.yml`.
+Then tag the commit and Github Actions should perform the rest.
+
+    git tag v1
+    git push --tags
+
+
 Credits
 =======
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,12 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.elasticsearch</groupId>
   <artifactId>elasticsearch-analysis-lemmagen</artifactId>
-  <version>8.6.1</version>
+  <version>8.9.2</version>
   <packaging>jar</packaging>
   <properties>
-    <plugin.version>8.6.1</plugin.version>
-    <lucene.version>9.4.2</lucene.version>
-    <elasticsearch.version>8.6.1</elasticsearch.version>
+    <plugin.version>8.9.2</plugin.version>
+    <lucene.version>9.7.0</lucene.version>
+    <elasticsearch.version>8.9.2</elasticsearch.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -86,13 +86,13 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>[2.16.0,)</version>
+      <version>2.20.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>[2.16.0,)</version>
+      <version>2.20.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,6 @@
   <packaging>jar</packaging>
   <properties>
     <plugin.version>8.9.2</plugin.version>
-    <lucene.version>9.7.0</lucene.version>
     <elasticsearch.version>8.9.2</elasticsearch.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
@@ -36,12 +35,6 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>1.6.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.lucene</groupId>
-      <artifactId>lucene-test-framework</artifactId>
-      <version>${lucene.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
   <version>8.9.2</version>
   <packaging>jar</packaging>
   <properties>
-    <plugin.version>8.9.2</plugin.version>
     <elasticsearch.version>8.9.2</elasticsearch.version>
+    <plugin.version>${elasticsearch.version}</plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <dependencies>


### PR DESCRIPTION
Hi, we use your plugin. To be able to upgrade ES versions, I've automated the release process. If you're interested in it, here you are.

There are a few smaller changes bundled:

- Tests were not being run because Log4j 3.0 alpha1 was used. I couldn't make it work with version range so I just hardcoded Log4j version - the same as other dependencies.
- It seems enough to get Lucene that comes with ES and we don't need to specify its version here.
- I separated this plugin version number from the ES version number. Basically copied from monitora-media/es-utils where we need to make changes to the plugin independently from ES upgrades.