### PR TITLE
fix: simplify project dependencies, fix tests

### DIFF
--- a/plugin-descriptor.properties
+++ b/plugin-descriptor.properties
@@ -1,6 +1,6 @@
 description=Lemmatizer token filter
-version=${elasticsearch.version}
+version=${project.version}
 name=elasticsearch-analysis-lemmagen
 classname=org.elasticsearch.plugin.analysis.lemmagen.AnalysisLemmagenPlugin
 java.version=1.8
-elasticsearch.version=${plugin.version}
+elasticsearch.version=${elasticsearch.version}

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,6 @@
   <version>8.6.1</version>
   <packaging>jar</packaging>
   <properties>
-    <plugin.version>8.6.1</plugin.version>
-    <lucene.version>9.4.2</lucene.version>
     <elasticsearch.version>8.6.1</elasticsearch.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
@@ -29,70 +27,14 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>1.6.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>1.6.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.lucene</groupId>
-      <artifactId>lucene-test-framework</artifactId>
-      <version>${lucene.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <version>2.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <version>2.1</version>
-      <scope>test</scope>
+      <!-- explicitly matching eu.hlavki.text-jlemmagen org.slf4j-slf4j-api dependency version -->
+      <version>1.7.30</version>
     </dependency>
     <dependency>
       <groupId>org.elasticsearch.test</groupId>
       <artifactId>framework</artifactId>
       <version>${elasticsearch.version}</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-all</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.1</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-core</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>[2.16.0,)</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <version>[2.16.0,)</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -133,7 +75,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.14</version>
+        <version>3.2.2</version>
         <configuration>
           <!-- disable security manager for tests -->
           <argLine>-Dtests.security.manager=false</argLine>


### PR DESCRIPTION
Hello Vojtěchu ;) @vhyza,

My colleagues and I tried to experiment with your plugin, but realized the last published version is too old for our ES instance. Despite not being a java guy at all, I decided to give a custom build a try. Following your instructions to run `mvn package` indeed produced a .zip package, but the test was throwing an exception that was pretty impossible to decipher. I didn't feel like ignoring that and decided to make it work. There were some hints on the internet, that the dependencies might be clashing, so I tried to untangle them. I spend some non-trivial time on that and found those could be really simplified quite a bit. The ultimate fix was to bump the maven-surefire-plugin, though :face_exhaling: 

Going through all this - and succeeding - I thought I might share the result with you. I actually also found quite useful the [contribution from @crabhi](https://github.com/vhyza/elasticsearch-analysis-lemmagen/pull/38), which allowed me to write a very similar building Dockerfile, that dynamically sets both the (`plugin.version` replaced by) `project.version` and the targeted `elasticsearch.version`:
```dockerfile
ARG elasticsearch_version=8.7.1
FROM maven:3-eclipse-temurin-17-alpine as lemmagen
ARG elasticsearch_version
# we need a non-root user for the plugin tests to pass
RUN adduser -s /sbin/nologin -D builder
USER builder
# prevent access error in case of running this (otherwise ephemeral) image as a non-root user
ENV MAVEN_CONFIG=/home/builder/.m2
WORKDIR /home/builder/elasticsearch-analysis-lemmagen

COPY --chown=builder:builder . ./
RUN set -eu ;\
    mvn --no-transfer-progress versions:set -DnewVersion=$elasticsearch_version ;\
    mvn --no-transfer-progress package -Delasticsearch.version=$elasticsearch_version
```

With all that I'd like to thank you for sharing your code with the open source community, so we can all take part.